### PR TITLE
Bugfix for creating new ID/name node with mixed types (int/string) for $idname and $type

### DIFF
--- a/support/win_pe_file.php
+++ b/support/win_pe_file.php
@@ -1552,7 +1552,7 @@
 			$this->pe_data_dir["resources"]["dir_entries"][$num] = array(
 				"type" => "node",
 				"subtype" => (is_string($idname) ? "name" : "id"),
-				(is_string($idname) ? "name" : "id") => (is_string($type) ? $idname : (int)$idname),
+				(is_string($idname) ? "name" : "id") => (is_string($idname) ? $idname : (int)$idname),
 				"parent" => $parentnum,
 				"pos" => 0,
 				"flags" => 0,
@@ -1615,7 +1615,7 @@
 			$this->pe_data_dir["resources"]["dir_entries"][$num] = array(
 				"type" => "leaf",
 				"subtype" => (is_string($lang) ? "name" : "id"),
-				(is_string($lang) ? "name" : "id") => (is_string($type) ? $lang : (int)$lang),
+				(is_string($lang) ? "name" : "id") => (is_string($lang) ? $lang : (int)$lang),
 				"parent" => $parentnum,
 				"pos" => 0,
 				"rva" => 0,


### PR DESCRIPTION
The WinPEFile.CreateResourceIDNameNode() method adds a new node to the directory entries and either provides a `name`, if $idname is a string, or else it provides an `id`, if $idname is an integer. 

Providing a the $idname as string (to use it as `name`, instead of `id`) does not currently work, if the $type is provided as integer (which should be unrelated to the type of `$name` in my understanding), see line [1555](https://github.com/cubiclesoft/php-winpefile/compare/master...ingo-budde:master#diff-0b5ecb51aa006d33feb54a1fa659c559L1555).

This fix allows the variables $lang, $type, $idname to be either a string or an int independently of each other, which is actually allowed in PE (I think, at least, I do that in my MSVC17 project).
