### PR TITLE
Add a section to the data directory

### DIFF
--- a/support/win_pe_file.php
+++ b/support/win_pe_file.php
@@ -525,6 +525,7 @@
 				"iat" => array("rva" => 0, "size" => 0),  // Import Address Table.
 				"delay_imports" => array("rva" => 0, "size" => 0),  // Delay-load import tables.
 				"clr_runtime_header" => array("rva" => 0, "size" => 0),  // .NET CLR header.  .cormeta section.
+				"reserved" => array("rva" => 0, "size" => 0),  // IMAGE_DIRECTORY_ENTRY_RESERVED in python pefile
 			);
 
 			return $result;


### PR DESCRIPTION
The corresponding data directory description in python pefile library (directory_entry_types collection) has one more field IMAGE_DIRECTORY_ENTRY_RESERVED
https://github.com/erocarrera/pefile/blob/master/pefile.py#L163

I have encountered a file (created by python pefile lib) with non-zero values in this header area named "reserved" and the problem with that file was that after parsing PE file and calling SaveHeaders the contents of the $data changed.

The last bytes at the end of the header were changed from non-zero to zero values by this code on line 2031:
if ($x < $x2)  self::SetBytes($data, $x, "", $x2 - $x);

https://github.com/cubiclesoft/php-winpefile/blob/master/support/win_pe_file.php#L2031

The data in that "reserved" section of the header is probably an extremely rare condition. I have checked all files in C:\Program Files dirs and have found no files where these bytes in header would have non-zero values. Unfortunately I cannot share my problematic file that has "reserved" section.

P.S. sorry for the new line at the end of file, it was added by github editor.